### PR TITLE
Ensure the base jar is ready for use

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -33,4 +33,4 @@ jobs:
         with:
           args: |
             build/libs/mc-kotlin-plugin-template-${{ steps.format-version.outputs.replaced }}.jar
-            build/libs/mc-kotlin-plugin-template-${{ steps.format-version.outputs.replaced }}-all.jar
+            build/libs/mc-kotlin-plugin-template-${{ steps.format-version.outputs.replaced }}-nokt.jar

--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Opinionated template/starter for creating Minecraft plugins in Kotlin using the 
   - automatic updating of `CHANGELOG.md` and `main/resources/plugin.yml` when a release is made
 - Github Actions to build PRs and automatically create Github releases when a release tag is pushed
 - [`ktlint`](https://github.com/JLLeitschuh/ktlint-gradle) Gradle plugin
-- Gradle build generates both a shadow jar which includes kotlin stdlib and a normal jar without
+- Gradle build generates a shadowed jar which includes kotlin stdlib and a `nokt` jar without
   - Users with the stdlib already on the classpath can use the smaller jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import pl.allegro.tech.build.axion.release.domain.hooks.HookContext
 import pl.allegro.tech.build.axion.release.domain.hooks.HooksConfig
 import java.time.OffsetDateTime
@@ -101,17 +100,29 @@ tasks {
         distributionType = Wrapper.DistributionType.ALL
     }
 
-    withType<KotlinCompile> {
+    compileKotlin {
         kotlinOptions {
             jvmTarget = "1.8"
         }
     }
 
-    withType<ShadowJar> {
+    // standard jar should be ready to go with all dependencies
+    shadowJar {
         minimize()
+        archiveClassifier.set("")
+    }
+
+    // nokt jar without the kotlin runtime
+    register<ShadowJar>("nokt") {
+        minimize()
+        archiveClassifier.set("nokt")
+
+        dependencies {
+            exclude("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+        }
     }
 
     build {
-        dependsOn(":shadowJar")
+        dependsOn(":shadowJar", ":nokt")
     }
 }


### PR DESCRIPTION
Standard jar is the full-fat jar with all dependencies (kotlin stdlib included)
Added `nokt` task to create a shadowed jar excluding kotlin stdlib